### PR TITLE
BREAKING CHANGE: Support for flexible server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 ## Introduction
 
-This module manages resources for Azure DB for MySQL.
+This module manages resources for Azure DB for MySQL using the flexible server deployment.
+
+More details are available in the following sources:
+
+- [Terraform AzureRM provider flexible server resource type](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_flexible_server)
+- [Microsoft flexible server documentation](https://learn.microsoft.com/en-us/azure/mysql/flexible-server/)
 
 ## Usage
 
@@ -34,11 +39,12 @@ No modules.
 
 The following resources are used by this module:
 
-- [azurerm_mysql_database.db](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_database) (resource)
-- [azurerm_mysql_firewall_rule.firewall](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_firewall_rule) (resource)
-- [azurerm_mysql_server.server](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_server) (resource)
-- [azurerm_mysql_virtual_network_rule.virtualnetworks](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_virtual_network_rule) (resource)
-- [azurerm_private_endpoint.mysql-private-endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
+- [azurerm_mysql_flexible_database.db](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_flexible_database) (resource)
+- [azurerm_mysql_flexible_server.server](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_flexible_server) (resource)
+- [azurerm_mysql_flexible_server_configuration.configuration](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_flexible_server_configuration) (resource)
+- [azurerm_mysql_flexible_server_configuration.require-secure-transport](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_flexible_server_configuration) (resource)
+- [azurerm_mysql_flexible_server_configuration.tls-version](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_flexible_server_configuration) (resource)
+- [azurerm_mysql_flexible_server_firewall_rule.firewall](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_flexible_server_firewall_rule) (resource)
 
 ## Required Inputs
 
@@ -52,14 +58,13 @@ Type: `string`
 
 ### charset
 
-Description: Charset for the databases, which needs to be a valid PostgreSQL charset
+Description: Charset for the databases, which needs to be a valid MySQL charset
 
 Type: `string`
 
 ### collation
 
-Description:     Collation for the databases, which needs to be a valid PostgreSQL collation. Note that Microsoft uses  
-    different notation - f.e. en-US instead of en\_US
+Description: Charset for the databases, which needs to be a valid MySQL charset
 
 Type: `string`
 
@@ -122,6 +127,14 @@ map(object({
 
 Default: `{}`
 
+### availability\_zone
+
+Description: The availability zone the server will be created in
+
+Type: `string`
+
+Default: `"1"`
+
 ### backup\_retention\_days
 
 Description: Number of days to keep backups
@@ -130,21 +143,45 @@ Type: `number`
 
 Default: `7`
 
+### configurations
+
+Description: Additional MySQL configurations
+
+Type: `map(string)`
+
+Default: `{}`
+
 ### database\_host\_sku
 
 Description: SKU for the database server to use
 
 Type: `string`
 
-Default: `"GP_Gen5_2"`
+Default: `"GP_Standard_D4ds_v4"`
 
-### database\_storage
+### database\_storage\_autogrow
 
-Description: Required database storage (in MB)
+Description: Autogrow storage when limit is reached?
+
+Type: `bool`
+
+Default: `true`
+
+### database\_storage\_iops
+
+Description: IO operations per second
+
+Type: `number`
+
+Default: `3600`
+
+### database\_storage\_size
+
+Description: Required database storage (in GB)
 
 Type: `string`
 
-Default: `"5120"`
+Default: `"20"`
 
 ### database\_version
 
@@ -152,26 +189,43 @@ Description: Database version to use
 
 Type: `string`
 
-Default: `"8.0"`
+Default: `"8.0.21"`
 
-### public\_access
+### delegated\_subnet\_id
 
-Description:     Wether to allow public access to the database server. True will create firewall rules for allowed\_ips and for subnets. False will  
-    create a private endpoint in each given subnet (allowed\_ips will not be used then) - you have to set  
-    enforce\_private\_link\_endpoint\_network\_policies = true on your subnet in this case (see  
-    https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet#enforce_private_link_endpoint_network_policies).
+Description: The id of a subnet that the server will be created in if private-only access is required.  
+This subnet requires a service delegation definition like this:
+```hcl
+  delegation {
+    name = "fs"
+    service_delegation {
+      name = "Microsoft.DBforMySQL/flexibleServers"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+    }
+  }
+```
+
+Type: `string`
+
+Default: `null`
+
+### geo\_redundant\_backup\_enabled
+
+Description: Whether backups should be geo redundant
 
 Type: `bool`
 
 Default: `false`
 
-### subnets
+### private\_dns\_zone\_id
 
-Description: Maps of prefix => subnet id that has access to the server
+Description: The id of the private dns zone when using private-only access
 
-Type: `map(string)`
+Type: `string`
 
-Default: `{}`
+Default: `null`
 
 ### suffix
 

--- a/configuration.tf
+++ b/configuration.tf
@@ -1,0 +1,21 @@
+resource "azurerm_mysql_flexible_server_configuration" "require-secure-transport" {
+  resource_group_name = var.resource_group
+  server_name         = azurerm_mysql_flexible_server.server.name
+  name                = "require_secure_transport"
+  value               = "ON"
+}
+
+resource "azurerm_mysql_flexible_server_configuration" "tls-version" {
+  resource_group_name = var.resource_group
+  server_name         = azurerm_mysql_flexible_server.server.name
+  name                = "tls_version"
+  value               = "TLSv1.2"
+}
+
+resource "azurerm_mysql_flexible_server_configuration" "configuration" {
+  for_each            = var.configurations
+  resource_group_name = var.resource_group
+  server_name         = azurerm_mysql_flexible_server.server.name
+  name                = each.key
+  value               = each.value
+}

--- a/databases.tf
+++ b/databases.tf
@@ -1,8 +1,8 @@
-resource "azurerm_mysql_database" "db" {
+resource "azurerm_mysql_flexible_database" "db" {
   for_each            = toset(var.database_suffixes)
-  name                = "${var.project}${var.stage}db${each.value}"
   resource_group_name = var.resource_group
-  server_name         = azurerm_mysql_server.server.name
+  server_name         = azurerm_mysql_flexible_server.server.name
+  name                = "${var.project}${var.stage}db${each.value}"
   charset             = var.charset
   collation           = var.collation
 }

--- a/firewall.tf
+++ b/firewall.tf
@@ -1,31 +1,8 @@
-resource "azurerm_mysql_firewall_rule" "firewall" {
-  for_each            = var.public_access == true ? var.allowed_ips : {}
+resource "azurerm_mysql_flexible_server_firewall_rule" "firewall" {
+  for_each            = var.allowed_ips
   start_ip_address    = each.value.start
   end_ip_address      = each.value.end
   name                = "${var.project}${var.stage}dbfw${each.key}"
   resource_group_name = var.resource_group
-  server_name         = azurerm_mysql_server.server.name
-}
-
-resource "azurerm_mysql_virtual_network_rule" "virtualnetworks" {
-  for_each            = var.public_access == true ? var.subnets : {}
-  name                = "${var.project}${var.stage}dbfwnet${each.key}"
-  resource_group_name = var.resource_group
-  server_name         = azurerm_mysql_server.server.name
-  subnet_id           = each.value
-}
-
-resource "azurerm_private_endpoint" "mysql-private-endpoint" {
-  for_each            = var.public_access == false ? var.subnets : {}
-  name                = "${each.value}-mysql-${azurerm_mysql_server.server.id}-endpoint"
-  location            = var.location
-  resource_group_name = var.resource_group
-  subnet_id           = each.value
-
-  private_service_connection {
-    name                           = "${each.value}-mysql-${azurerm_mysql_server.server.id}-privateserviceconnection"
-    private_connection_resource_id = azurerm_mysql_server.server.id
-    subresource_names              = ["mysqlServer"]
-    is_manual_connection           = false
-  }
+  server_name         = azurerm_mysql_flexible_server.server.name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "server_fqdn" {
   description = "FQDN of the database service"
-  value       = azurerm_mysql_server.server.fqdn
+  value       = azurerm_mysql_flexible_server.server.fqdn
 }
 
 output "admin_login" {
@@ -12,7 +12,7 @@ output "admin_password" {
 }
 
 output "databases" {
-  value = length(azurerm_mysql_database.db) > 0 ? {
-    for index, suffix in var.database_suffixes : suffix => azurerm_mysql_database.db[suffix].name
+  value = length(azurerm_mysql_flexible_database.db) > 0 ? {
+    for index, suffix in var.database_suffixes : suffix => azurerm_mysql_flexible_database.db[suffix].name
   } : {}
 }

--- a/server.tf
+++ b/server.tf
@@ -1,18 +1,29 @@
-resource "azurerm_mysql_server" "server" {
-  name                          = "${var.project}${var.stage}dbsrv"
-  location                      = var.location
-  resource_group_name           = var.resource_group
-  administrator_login           = var.admin_login
-  administrator_login_password  = var.admin_password
-  sku_name                      = var.database_host_sku
-  storage_mb                    = var.database_storage
-  version                       = var.database_version
-  backup_retention_days         = var.backup_retention_days
-  public_network_access_enabled = var.public_access
+resource "azurerm_mysql_flexible_server" "server" {
+  name                   = "${var.project}${var.stage}dbsrv"
+  location               = var.location
+  resource_group_name    = var.resource_group
+  administrator_login    = var.admin_login
+  administrator_password = var.admin_password
+  sku_name               = var.database_host_sku
+  storage {
+    size_gb           = var.database_storage_size
+    auto_grow_enabled = var.database_storage_autogrow
+    iops              = var.database_storage_iops
+  }
+  version               = var.database_version
+  backup_retention_days = var.backup_retention_days
 
-  auto_grow_enabled                 = true
-  geo_redundant_backup_enabled      = false
-  infrastructure_encryption_enabled = true
-  ssl_enforcement_enabled           = true
-  ssl_minimal_tls_version_enforced  = "TLS1_2"
+  delegated_subnet_id = var.delegated_subnet_id
+  private_dns_zone_id = var.private_dns_zone_id
+
+  geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
+
+  zone = var.availability_zone
+
+  lifecycle {
+    precondition {
+      condition     = (var.private_dns_zone_id == null && var.delegated_subnet_id == null) || (var.private_dns_zone_id != null && var.delegated_subnet_id != null)
+      error_message = "The parameter private_dns_zone_id requires the parameter delegated_subnet_id and vice versa."
+    }
+  }
 }


### PR DESCRIPTION
This commit switches from the deprecated single server solution to the new flexible server.

The configuration is nearly the same as before, but the different network handling makes the configuration incompatible.

Warning: Using this version DESTROYS the previously deployed server, so a manual migration using dumps and restore is required.

Additionally, additional mysql configurations are supported in this as well.